### PR TITLE
Duplicated stream block processing

### DIFF
--- a/client.go
+++ b/client.go
@@ -209,7 +209,7 @@ func DoArrow[R any](ctx context.Context, c *Client, url string, method string, p
 		responseData, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("unexpected status code: %d, response: %s", resp.StatusCode, string(responseData))
 	}
-	
+
 	arrowReader, err := arrowhs.NewQueryResponseReader(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not parse the ipc/arrow response while attempting to read")

--- a/stream.go
+++ b/stream.go
@@ -89,6 +89,11 @@ func (s *Stream) Subscribe() error {
 		return nil
 	}
 
+	// Create a new iterator starting from the NextBlock to avoid duplicate processing
+	nextBlockValue := response.NextBlock.Uint64()
+	step := s.opts.BatchSize.Uint64() | (uint64(0) << 32)
+	s.iterator = streams.NewBlockIterator(nextBlockValue, s.query.ToBlock.Uint64(), &step)
+
 	// Start the worker to fetch remaining pages
 	g.Go(func() error {
 		return s.worker.Start(s.ProcessNextQuery, s.queryCh)

--- a/streams/worker.go
+++ b/streams/worker.go
@@ -85,7 +85,6 @@ func (w *Worker[T, R]) Start(workerFn WorkerFn[T, R], descriptor <-chan T) error
 					if !ok {
 						return nil
 					}
-
 					w.wg.Add(1)
 					resp, err := workerFn(entry.value)
 					w.result <- OrderedResult[T, R]{index: entry.index, record: resp, err: err}


### PR DESCRIPTION
Have this branch here for some time, seeing I did not create PR.

Basically it's a hotfix where when you're requesting large block of numbers, occasionally happens a race condition, resulting in duplicated block numbers being delivered. Instantiating it a new, on each next block stream download sorts out this issue. 